### PR TITLE
Add support for custom CSS width/height

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ ReactDOM.render(<QierPlayer srcOrigin="Your video addedress" />, document.getEle
 ## API
 | Parameter  |  Description | Types  | Defaults  |
 | ------------ | ------------ | ------------ | ------------ |
-| width  | setting the video `width`  | number  |  740 |
-| height  | setting the video `height`  | number  |  420 |
+| width  | setting the video width (e.g. `740` or `"100%"`) | number &#124; string  |  740 |
+| height  | setting the video height (e.g. `420` or `"100%"`)  | number &#124; string  |  420 |
 | language  | language option:'en' is English and  'zh' is Chinese  | string  |  'en' |
 | showVideoQuality  | Control the display and hide of the sharpness options  | boolean  |  false |
 | themeColor  | Change the theme color (currently only supports hexadecimal color)  | string  |  '#f23300' |

--- a/src/component/QierPlayer.js
+++ b/src/component/QierPlayer.js
@@ -20,8 +20,8 @@ class QierPlayer extends Component {
   componentDidMount() {
     // 设置用户给的视频播放器长宽
     const videoContainerElem = this.videoContainerRef.current;
-    videoContainerElem.style.width = `${this.props.width}px`;
-    videoContainerElem.style.height = `${this.props.height}px`;
+    videoContainerElem.style.width = typeof this.props.width === "string" ? this.props.width : `${this.props.width}px`;
+    videoContainerElem.style.height = typeof this.props.height === "string" ? this.props.height : `${this.props.height}px`;
 
     const videoElem = this.videoRef.current;
     // 设置定时器检测 3 秒后视频是否可用

--- a/src/component/QierPlayer.js
+++ b/src/component/QierPlayer.js
@@ -110,8 +110,8 @@ class QierPlayer extends Component {
 }
 
 QierPlayer.propTypes = {
-  width: PropTypes.number,
-  height: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   language: PropTypes.string,
   showVideoQuality: PropTypes.bool,
   themeColor: PropTypes.string,


### PR DESCRIPTION
Allows the user to pass a string with a percentage or `em` (such as `"100%"`) for width or height.